### PR TITLE
Improve exception info

### DIFF
--- a/src/WaybackMachine.php
+++ b/src/WaybackMachine.php
@@ -55,8 +55,19 @@ class WaybackMachine
         
         $data = $this->getUrl($url, array(), true);
         
-        if (!array_key_exists('content-location', $data))
-            throw new \Exception('An error occured. Page saving failed.');
+        if (!array_key_exists('content-location', $data)) {
+            $errorNum = 0;
+            
+            if (isset($data['http_code'])) {
+                preg_match("/ (\d{3}) /", $data['http_code'], $matches);
+                
+                if (sizeof($matches) == 2) {
+                    $errorNum = (int)$matches[1];
+                }
+            }
+
+            throw new \Exception('Page saving failed: ' . json_encode($data), $errorNum);
+        }    
         
         return 'https://web.archive.org' . $data['content-location'];
     }


### PR DESCRIPTION
Thank you for making this lib!

WayBack Machine replies with more info than the given one in the exception, ex:
```json
{
  "http_code": "HTTP/1.1 429 Too Many Requests",
  "server": "nginx/1.15.8",
  "date": "Mon, 08 Dec 2019 19:10:09 GMT",
  "content-type": "text/html",
  "content-length": "487",
  "connection": "keep-alive",
  "etag": "\"5db9ab48-1e7\""
}
```

This PR attempts to grab http code (`429`) to send it as exception code.